### PR TITLE
Shortened a Calendar app video tutorial title to prevent text cut-off.

### DIFF
--- a/TechEase/Tutorials/Calendar Tutorial Parts/CalendarVideoTutorial2.swift
+++ b/TechEase/Tutorials/Calendar Tutorial Parts/CalendarVideoTutorial2.swift
@@ -22,7 +22,7 @@ struct CalendarVideoTutorial2: View {
             VStack {
                 
                 // Arica: The video tutorial heading.
-                Text("Using the Calendar app on your iPad")
+                Text("iPad Calendar app tips")
                     .padding(.top, 30)
                     .font(.title)
                     .foregroundColor(Color("DarkBlue"))

--- a/TechEase/Tutorials/TheCalendarTutorial.swift
+++ b/TechEase/Tutorials/TheCalendarTutorial.swift
@@ -158,7 +158,7 @@ struct TheCalendarTutorial: View {
                     
                     HStack {
                         
-                        Text("Video 2: Using the Calendar app on your iPad")
+                        Text("Video 2: iPad Calendar app tips")
                             .font(.title3)
                             .foregroundColor(Color("Black"))
                             .padding(.leading)


### PR DESCRIPTION
Relates to Issue #27. 